### PR TITLE
License update

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at oss-coc@vmware.com.
+reported to the community leaders responsible for enforcement.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to sbom-composer
 
 The sbom-composer project team welcomes contributions from the community. Before you start working with sbom-composer, please
-read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be
+read our [Developer Certificate of Origin](https://wiki.linuxfoundation.org/dco). All contributions to this repository must be
 signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on
 as an open-source patch.
 
@@ -18,7 +18,7 @@ This is a rough outline of what a contributor's workflow looks like:
 Example:
 
 ``` shell
-git remote add upstream https://github.com/vmware-samples/sbom-composer.git
+git remote add upstream https://github.com/opensbom-generator/sbom-composer.git
 git checkout -b my-new-feature main
 git commit -a
 git push origin my-new-feature
@@ -26,7 +26,7 @@ git push origin my-new-feature
 
 ### Staying In Sync With Upstream
 
-When your branch gets out of sync with the vmware-samples/main branch, use the following to update:
+When your branch gets out of sync with the opensbom-generator/main branch, use the following to update:
 
 ``` shell
 git checkout my-new-feature

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ Proposals should cover the high-level objectives, use cases, and technical recom
 
 ## Lazy Consensus
 
-To maintain velocity in the sbom-composer project, the concept of [Lazy Consensus](http://en.osswiki.info/concepts/lazy_consensus) is practiced. Lazy Consensus is practiced for all projects and decisions in the `vmware-samples` org.
+To maintain velocity in the sbom-composer project, the concept of [Lazy Consensus](http://en.osswiki.info/concepts/lazy_consensus) is practiced. Lazy Consensus is practiced for all projects and decisions in the `opensbom-generator` org.
 
 Lazy consensus does _not_ apply to the process of:
 * Removal of maintainers from sbom-composer

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2022 VMware, Inc.  All rights reserved
+Copyright (c) 2023 The OpenSBOM Authors,  All rights reserved
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # SBOM Composer Maintainers
 
-[GOVERNANCE.md](https://github.com/vmware-samples/sbom-composer/blob/main/GOVERNANCE.md)
+[GOVERNANCE.md](https://github.com/opensbom-generator/sbom-composer/blob/main/GOVERNANCE.md)
 describes governance guidelines and maintainer responsibilities.
 
 ## Maintainers
@@ -9,3 +9,4 @@ describes governance guidelines and maintainer responsibilities.
 | --------------- | --------- | ----------- |
 | Ivana Atanasova | [ivanayov](https://github.com/ivanayov) | [VMware](https://www.github.com/vmware/) |
 | Velichka Atanasova | [avelichka](https://github.com/avelichka/) | [VMware](https://www.github.com/vmware/) |
+| Rose Judge | [rnjudge](https://github.com/rnjudge/) | [VMware](https://www.github.com/vmware/) |

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2022 VMware, Inc.
+Copyright 2022 The OpenSBOM Authors
 
 This product is licensed to you under the BSD 2 clause (the "License"). You may not use this product except in compliance with the License.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ go run sbom_compose.go -d <path-to-dir-with-spdx-files-to-compose> [flags]
 
 If testing local changes to some of the sbom-composer's packages, e.g. the `parser`, modify `cli/sbom_compose.go` imports:
 ```
-// "github.com/vmware-samples/sbom-composer/parser"
+// "github.com/opensbom-generator/sbom-composer/parser"
 "sbom-composer/parser"
 ```
 and `cli/go.mod` with:
@@ -50,7 +50,7 @@ To be added.
 ## Contributing
 
 The sbom-composer project team welcomes contributions from the community. Before you start working with sbom-composer, please
-read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be
+read our [Developer Certificate of Origin](https://wiki.linuxfoundation.org/dco). All contributions to this repository must be
 signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on
 as an open-source patch. For more detailed information, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,9 +1,9 @@
-module github.com/vmware-samples/sbom-composer/sbomcompose
+module github.com/opensbom-generator/sbom-composer/sbomcompose
 
 go 1.16
 
 require (
 	github.com/morikuni/aec v1.0.0
 	github.com/spf13/cobra v1.5.0
-	github.com/vmware-samples/sbom-composer/parser v0.0.0-20230226221936-9042055273ca
+	github.com/opensbom-generator/sbom-composer/parser v0.0.0-20230226221936-9042055273ca
 )

--- a/cli/sbom_compose.go
+++ b/cli/sbom_compose.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package main
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/morikuni/aec"
+	"github.com/opensbom-generator/sbom-composer/parser"
 	"github.com/spf13/cobra"
-	"github.com/vmware-samples/sbom-composer/parser"
 )
 
 const figletStr = `

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
 # SBOM-Composer report for <top level product name>

--- a/parser/build.go
+++ b/parser/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/build_test.go
+++ b/parser/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/config.go
+++ b/parser/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/document.go
+++ b/parser/document.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/go.mod
+++ b/parser/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-samples/sbom-composer/parser
+module github.com/opensbom-generator/sbom-composer/parser
 
 go 1.16
 

--- a/parser/go.sum
+++ b/parser/go.sum
@@ -1,6 +1,7 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/parser/load.go
+++ b/parser/load.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/read_config_test.go
+++ b/parser/read_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/save.go
+++ b/parser/save.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2023 The OpenSBOM Authors, All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package parser


### PR DESCRIPTION
Updates all references to vmware-samples, License and Copyright notes to be opensbom-generator and The OpenSBOM Authors instead.

Resolves #1 